### PR TITLE
feat: consumed (and exposed "via API") type

### DIFF
--- a/src/iso8601.erl
+++ b/src/iso8601.erl
@@ -29,6 +29,7 @@
 -type timestamp() :: {MegaSecs::integer(),
                       Secs::integer(),
                       MicroSecs::integer() | float()}.
+-export_type([timestamp/0]).
 -type format_opts() :: [{precision, secs | microsecs}].
 
 %% API


### PR DESCRIPTION
## Motivation

Used by [`kivra_core`](https://github.com/kivra/kivra_core/blob/9b9cdd9cca458374047c2de20ac7cac1e13a9785/src/scripts/backfill_events.erl#L71).